### PR TITLE
Update Odin and Raylib to the current versions as of now (fix #issue-2)

### DIFF
--- a/doq/asset.odin
+++ b/doq/asset.odin
@@ -64,9 +64,9 @@ asset_data : struct {
 		knightModel		: rl.Model,
 
 		knightAnim		: [^]rl.ModelAnimation,
-		knightAnimCount		: i32,
+		knightAnimCount		: u32,
 		gruntAnim		: [^]rl.ModelAnimation,
-		gruntAnimCount		: i32,
+		gruntAnimCount		: u32,
 	
 		gruntTexture		: rl.Texture2D,
 		knightTexture		: rl.Texture2D,
@@ -143,8 +143,8 @@ asset_loadPersistent :: proc() {
 	asset_data.healthPickupModel	= loadModel("healthpickup.glb")
 	asset_data.boxModel		= loadModel("box.glb")
 	asset_data.thornsModel		= loadModel("thorns.glb")
-	rl.SetMaterialTexture(&asset_data.tileModel.materials[0], rl.MaterialMapIndex.DIFFUSE, asset_data.wallTexture)
-	rl.SetMaterialTexture(&asset_data.elevatorModel.materials[0], rl.MaterialMapIndex.DIFFUSE, asset_data.elevatorTexture)
+	rl.SetMaterialTexture(&asset_data.tileModel.materials[0], rl.MaterialMapIndex.ALBEDO, asset_data.wallTexture)
+	rl.SetMaterialTexture(&asset_data.elevatorModel.materials[0], rl.MaterialMapIndex.ALBEDO, asset_data.elevatorTexture)
 	asset_data.tileModel.materials[0].shader	= asset_data.tileShader
 	asset_data.elevatorModel.materials[0].shader	= asset_data.tileShader
 	asset_data.boxModel.materials[1].shader		= asset_data.defaultShader
@@ -160,8 +160,8 @@ asset_loadPersistent :: proc() {
 	asset_data.enemy.knightAnim		= loadModelAnim("knight.iqm", &asset_data.enemy.knightAnimCount)
 	asset_data.enemy.gruntTexture		= loadTexture("grunt.png")
 	asset_data.enemy.knightTexture		= loadTexture("knight.png")
-	rl.SetMaterialTexture(&asset_data.enemy.gruntModel.materials[0],  rl.MaterialMapIndex.DIFFUSE, asset_data.enemy.gruntTexture)
-	rl.SetMaterialTexture(&asset_data.enemy.knightModel.materials[0], rl.MaterialMapIndex.DIFFUSE, asset_data.enemy.knightTexture)
+	rl.SetMaterialTexture(&asset_data.enemy.gruntModel.materials[0],  rl.MaterialMapIndex.ALBEDO, asset_data.enemy.gruntTexture)
+	rl.SetMaterialTexture(&asset_data.enemy.knightModel.materials[0], rl.MaterialMapIndex.ALBEDO, asset_data.enemy.knightTexture)
 	rl.SetSoundVolume(asset_data.enemy.gruntHitSound, 0.35)
 	rl.SetSoundPitch(asset_data.enemy.gruntHitSound, 1.3)
 

--- a/doq/doq.odin
+++ b/doq/doq.odin
@@ -72,7 +72,9 @@ app_updatePathKind_t :: enum {
 
 app_updatePathKind : app_updatePathKind_t
 
-
+main :: proc() {
+	_doq_main()
+}
 
 // this just gets called from main
 _doq_main :: proc() {
@@ -119,8 +121,8 @@ _doq_main :: proc() {
 			case .GAME:
 			// main game update path
 			{
-				rl.UpdateCamera(&camera)
-				rl.UpdateCamera(&viewmodelCamera)
+				rl.UpdateCamera(&camera, rl.CameraMode.CUSTOM)
+				rl.UpdateCamera(&viewmodelCamera, rl.CameraMode.CUSTOM)
 
 				_app_update()
 
@@ -215,7 +217,7 @@ _app_init :: proc() {
 	windowSizeX = rl.GetScreenWidth()
 	windowSizeY = rl.GetScreenHeight()
 
-	rl.SetExitKey(rl.KeyboardKey.NULL)
+	rl.SetExitKey(rl.KeyboardKey.KEY_NULL)
 	rl.SetTargetFPS(120)
 	//rl.SetTargetFPS(10)
 
@@ -234,13 +236,13 @@ _app_init :: proc() {
 	camera.target = {}
 	camera.up = vec3{0.0, 1.0, 0.0}
 	camera.projection = rl.CameraProjection.PERSPECTIVE
-	rl.SetCameraMode(camera, rl.CameraMode.CUSTOM)
+	//rl.SetCameraMode(camera, rl.CameraMode.CUSTOM)
 
 	viewmodelCamera.position = {0,0,0}
 	viewmodelCamera.target = {0,0,1}
 	viewmodelCamera.up = {0,1,0}
 	viewmodelCamera.projection = rl.CameraProjection.PERSPECTIVE
-	rl.SetCameraMode(viewmodelCamera, rl.CameraMode.CUSTOM)
+	//rl.SetCameraMode(viewmodelCamera, rl.CameraMode.CUSTOM)
 
 
 
@@ -1083,7 +1085,7 @@ loadModel :: proc(path : string) -> rl.Model {
 	return rl.LoadModel(fullpath)
 }
 
-loadModelAnim :: proc(path : string, outCount : ^i32) -> [^]rl.ModelAnimation {
+loadModelAnim :: proc(path : string, outCount : ^u32) -> [^]rl.ModelAnimation {
 	fullpath := appendToAssetPathCstr("anim", path)
 	println("! loading anim: ", fullpath)
 	return rl.LoadModelAnimations(fullpath, outCount)
@@ -1112,7 +1114,7 @@ playSound :: proc(sound : rl.Sound) {
 
 playSoundMulti :: proc(sound : rl.Sound) {
 	if !rl.IsAudioDeviceReady() do return
-	rl.PlaySoundMulti(sound)
+	//rl.PlaySoundMulti(sound)
 }
 
 // rand vector with elements in -1..1

--- a/doq/gui/gui.odin
+++ b/doq/gui/gui.odin
@@ -102,7 +102,7 @@ updateAndDrawElemBuf :: proc(elems : []menuElem_t) -> bool {
 		if !rl.IsKeyDown(rl.KeyboardKey.LEFT_CONTROL) {
 			loopfind: for i := 0; i < len(elems); i += 1 {
 				index := (int(menuContext.selected) + i*selectDir + selectDir) %% len(elems)
-				#partial switch in elems[index] {
+				#partial switch _ in elems[index] {
 					case menuTitle_t: continue loopfind
 				}
 				menuContext.selected = i32(index)
@@ -111,7 +111,7 @@ updateAndDrawElemBuf :: proc(elems : []menuElem_t) -> bool {
 		} else { // jump between titles (also stops at first/last elem)
 			loopfindjump: for i := 0; i < len(elems); i += 1 {
 				index := (int(menuContext.selected) + i*selectDir + selectDir) %% len(elems)
-				#partial switch in elems[index] {
+				#partial switch _ in elems[index] {
 					case menuTitle_t:
 						menuContext.selected = i32(index + selectDir)
 						break loopfindjump

--- a/doq/map.odin
+++ b/doq/map.odin
@@ -382,7 +382,7 @@ map_drawTilemap :: proc() {
 
 	rl.BeginShaderMode(asset_data.portalShader)
 	// draw finish
-	rl.DrawCubeTexture(asset_data.portalTexture, map_data.finishPos, MAP_TILE_FINISH_SIZE.x*2, MAP_TILE_FINISH_SIZE.y*2, MAP_TILE_FINISH_SIZE.z*2, rl.WHITE)
+	doqDrawCubeTexture(asset_data.portalTexture, map_data.finishPos, MAP_TILE_FINISH_SIZE.x*2, MAP_TILE_FINISH_SIZE.y*2, MAP_TILE_FINISH_SIZE.z*2, rl.WHITE)
 	rl.EndShaderMode()
 	rl.DrawCube(map_data.finishPos,-MAP_TILE_FINISH_SIZE.x*2-4,-MAP_TILE_FINISH_SIZE.y*2-4,-MAP_TILE_FINISH_SIZE.z*2-4, {0,0,0,40})
 	rl.DrawCube(map_data.finishPos,-MAP_TILE_FINISH_SIZE.x*2-2,-MAP_TILE_FINISH_SIZE.y*2-2,-MAP_TILE_FINISH_SIZE.z*2-2, {0,0,0,60})
@@ -452,12 +452,12 @@ map_drawTilemap :: proc() {
 		W :: 2048
 		c : vec3 = player_data.pos
 		rl.BeginShaderMode(asset_data.cloudShader)
-		rl.DrawCubeTexture(asset_data.cloudTexture, vec3{c.x,+TILE_HEIGHT*1.6,c.z}, W,1,W, {255,255,255,50})
-		rl.DrawCubeTexture(asset_data.cloudTexture, vec3{c.x,+TILE_HEIGHT*1.0,c.z}, W,1,W, {255,255,255,40})
-		rl.DrawCubeTexture(asset_data.cloudTexture, vec3{c.x,+TILE_HEIGHT*0.6,c.z}, W,1,W, {255,255,255,20})
-		rl.DrawCubeTexture(asset_data.cloudTexture, vec3{c.x,-TILE_HEIGHT*1.6,c.z}, W,1,W, {200,200,200,60})
-		rl.DrawCubeTexture(asset_data.cloudTexture, vec3{c.x,-TILE_HEIGHT*1.0,c.z}, W,1,W, {200,200,200,40})
-		rl.DrawCubeTexture(asset_data.cloudTexture, vec3{c.x,-TILE_HEIGHT*0.6,c.z}, W,1,W, {255,255,255,20})
+		doqDrawCubeTexture(asset_data.cloudTexture, vec3{c.x,+TILE_HEIGHT*1.6,c.z}, W,1,W, {255,255,255,50})
+		doqDrawCubeTexture(asset_data.cloudTexture, vec3{c.x,+TILE_HEIGHT*1.0,c.z}, W,1,W, {255,255,255,40})
+		doqDrawCubeTexture(asset_data.cloudTexture, vec3{c.x,+TILE_HEIGHT*0.6,c.z}, W,1,W, {255,255,255,20})
+		doqDrawCubeTexture(asset_data.cloudTexture, vec3{c.x,-TILE_HEIGHT*1.6,c.z}, W,1,W, {200,200,200,60})
+		doqDrawCubeTexture(asset_data.cloudTexture, vec3{c.x,-TILE_HEIGHT*1.0,c.z}, W,1,W, {200,200,200,40})
+		doqDrawCubeTexture(asset_data.cloudTexture, vec3{c.x,-TILE_HEIGHT*0.6,c.z}, W,1,W, {255,255,255,20})
 		rl.EndShaderMode()
 	}
 }

--- a/doq/raylib_util.odin
+++ b/doq/raylib_util.odin
@@ -85,4 +85,6 @@ doqDrawCubeTexture :: proc(
 
 	rl.rlEnd()
 
+	rl.rlSetTexture(0)
+
 }

--- a/doq/raylib_util.odin
+++ b/doq/raylib_util.odin
@@ -1,0 +1,88 @@
+package doq
+
+import rl "vendor:raylib"
+
+/*
+ *  Adapted from https://github.com/raysan5/raylib/blob/master/examples/models/models_draw_cube_texture.c
+ *  Since this is no longer a part of Raylib core itself
+ */
+
+doqDrawCubeTexture :: proc(
+	texture: rl.Texture2D,
+	position: rl.Vector3,
+	width, height, length: f32,
+	color: rl.Color,
+) {
+	x := position.x
+	y := position.y
+	z := position.z
+
+	rl.rlSetTexture(texture.id)
+
+	rl.rlBegin(rl.RL_QUADS)
+
+	rl.rlColor4ub(color.r, color.g, color.b, color.a)
+	// Front Face
+	rl.rlNormal3f(0.0, 0.0, 1.0) // Normal Pointing Towards Viewer
+	rl.rlTexCoord2f(0.0, 0.0)
+	rl.rlVertex3f(x - width / 2, y - height / 2, z + length / 2) // Bottom Left Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 0.0)
+	rl.rlVertex3f(x + width / 2, y - height / 2, z + length / 2) // Bottom Right Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 1.0)
+	rl.rlVertex3f(x + width / 2, y + height / 2, z + length / 2) // Top Right Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 1.0)
+	rl.rlVertex3f(x - width / 2, y + height / 2, z + length / 2) // Top Left Of The Texture and Quad
+	// Back Face
+	rl.rlNormal3f(0.0, 0.0, -1.0) // Normal Pointing Away From Viewer
+	rl.rlTexCoord2f(1.0, 0.0)
+	rl.rlVertex3f(x - width / 2, y - height / 2, z - length / 2) // Bottom Right Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 1.0)
+	rl.rlVertex3f(x - width / 2, y + height / 2, z - length / 2) // Top Right Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 1.0)
+	rl.rlVertex3f(x + width / 2, y + height / 2, z - length / 2) // Top Left Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 0.0)
+	rl.rlVertex3f(x + width / 2, y - height / 2, z - length / 2) // Bottom Left Of The Texture and Quad
+	// Top Face
+	rl.rlNormal3f(0.0, 1.0, 0.0) // Normal Pointing Up
+	rl.rlTexCoord2f(0.0, 1.0)
+	rl.rlVertex3f(x - width / 2, y + height / 2, z - length / 2) // Top Left Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 0.0)
+	rl.rlVertex3f(x - width / 2, y + height / 2, z + length / 2) // Bottom Left Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 0.0)
+	rl.rlVertex3f(x + width / 2, y + height / 2, z + length / 2) // Bottom Right Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 1.0)
+	rl.rlVertex3f(x + width / 2, y + height / 2, z - length / 2) // Top Right Of The Texture and Quad
+	// Bottom Face
+	rl.rlNormal3f(0.0, -1.0, 0.0) // Normal Pointing Down
+	rl.rlTexCoord2f(1.0, 1.0)
+	rl.rlVertex3f(x - width / 2, y - height / 2, z - length / 2) // Top Right Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 1.0)
+	rl.rlVertex3f(x + width / 2, y - height / 2, z - length / 2) // Top Left Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 0.0)
+	rl.rlVertex3f(x + width / 2, y - height / 2, z + length / 2) // Bottom Left Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 0.0)
+	rl.rlVertex3f(x - width / 2, y - height / 2, z + length / 2) // Bottom Right Of The Texture and Quad
+	// Right face
+	rl.rlNormal3f(1.0, 0.0, 0.0) // Normal Pointing Right
+	rl.rlTexCoord2f(1.0, 0.0)
+	rl.rlVertex3f(x + width / 2, y - height / 2, z - length / 2) // Bottom Right Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 1.0)
+	rl.rlVertex3f(x + width / 2, y + height / 2, z - length / 2) // Top Right Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 1.0)
+	rl.rlVertex3f(x + width / 2, y + height / 2, z + length / 2) // Top Left Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 0.0)
+	rl.rlVertex3f(x + width / 2, y - height / 2, z + length / 2) // Bottom Left Of The Texture and Quad
+	// Left Face
+	rl.rlNormal3f(-1.0, 0.0, 0.0) // Normal Pointing Left
+	rl.rlTexCoord2f(0.0, 0.0)
+	rl.rlVertex3f(x - width / 2, y - height / 2, z - length / 2) // Bottom Left Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 0.0)
+	rl.rlVertex3f(x - width / 2, y - height / 2, z + length / 2) // Bottom Right Of The Texture and Quad
+	rl.rlTexCoord2f(1.0, 1.0)
+	rl.rlVertex3f(x - width / 2, y + height / 2, z + length / 2) // Top Right Of The Texture and Quad
+	rl.rlTexCoord2f(0.0, 1.0)
+	rl.rlVertex3f(x - width / 2, y + height / 2, z - length / 2) // Top Left Of The Texture and Quad
+
+	rl.rlEnd()
+
+}

--- a/main.odin
+++ b/main.odin
@@ -4,6 +4,3 @@ import "doq"
 
 
 
-main :: proc() {
-	doq._doq_main()
-}


### PR DESCRIPTION
Update the project to the current Odin and Raylib versions.

The changes are quite minor. The most noticeable are:
- `PlaySoundMulti()` is no longer a part of Raylib and there's no alternative (ctrl+f `PlaySoundMulti()` in https://raw.githubusercontent.com/raysan5/raylib/master/CHANGELOG)
- `DrawCubeTexture()` has the same fate. But I was able to rewrite it in Odin and add as a util function to the project.
- `SetCameraMode()` is no more, but there's no mention about it anywhere, at least I haven't found. It looks like its function has been merged into `UpdateCamera()`
- I had to move the `main()` proc into `doq.odin` because otherwise it couldn't find it.
- And other